### PR TITLE
Add auto.tfvars file

### DIFF
--- a/terraform.auto.tfvars
+++ b/terraform.auto.tfvars
@@ -1,0 +1,1 @@
+instance_type = "t2.micro"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Set the default cloud instance type to t2.micro for Terraform-managed resources. New deployments will use this size unless explicitly overridden.
  * Applies to all environments provisioned via Terraform; no changes to application features or behavior.
  * May influence resource capacity and associated cloud billing for newly created infrastructure; review and adjust your deployment variables if a different instance size is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->